### PR TITLE
fix exception in post application/json data

### DIFF
--- a/rest_framework_proxy/views.py
+++ b/rest_framework_proxy/views.py
@@ -169,6 +169,13 @@ class ProxyView(BaseProxyView):
                         timeout=self.proxy_settings.TIMEOUT,
                         verify=verify_ssl)
             else:
+                if 'application/json' in headers['Content-Type']:
+                    import json
+                    try:
+                        data = json.dumps(data)
+                    except:
+                        data = {}
+
                 response = requests.request(request.method, url,
                         params=params,
                         data=data,
@@ -176,12 +183,14 @@ class ProxyView(BaseProxyView):
                         headers=headers,
                         timeout=self.proxy_settings.TIMEOUT,
                         verify=verify_ssl)
+
         except (ConnectionError, SSLError):
             status = requests.status_codes.codes.bad_gateway
             return self.create_error_response({
                 'code': status,
                 'error': 'Bad gateway',
             }, status)
+
         except (Timeout):
             status = requests.status_codes.codes.gateway_timeout
             return self.create_error_response({


### PR DESCRIPTION
hey guys

while playing with your lib (thanks for that BTW), I noticed that sending data in POST with application/json content-type raises an exception 

```
AttributeError: 'dict' object has no attribute 'dict'
```

I assume it is because restframework is already parsing the request data with default jsonparser, as described [here](http://www.django-rest-framework.org/api-guide/requests). 

removing the `.dict()` call fixes the problem, but I confess I didn't test it extensively

please let me know if it makes sense, I'm running restframework 2.4.3 and django 1.7.1
