### PR TITLE
fix for PR #7

### DIFF
--- a/rest_framework_proxy/views.py
+++ b/rest_framework_proxy/views.py
@@ -54,7 +54,7 @@ class ProxyView(BaseProxyView):
         return {}
 
     def get_request_data(self, request):
-        if request.content_type == 'application/json':
+        if 'application/json' in request.content_type:
             return json.dumps(request.DATA) if request.DATA \
                     else json.dumps(request.data)
 

--- a/rest_framework_proxy/views.py
+++ b/rest_framework_proxy/views.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import requests
 
 from django.utils import six
@@ -53,10 +54,11 @@ class ProxyView(BaseProxyView):
         return {}
 
     def get_request_data(self, request):
-        data = {}
-        if request.DATA:
-            data.update(request.DATA)
-        return data
+        if request.content_type == 'application/json':
+            return json.dumps(request.DATA) if request.DATA \
+                    else json.dumps(request.data)
+
+        return request.DATA if request.DATA else request.data
 
     def get_request_files(self, request):
         files = {}


### PR DESCRIPTION
If the proxy receives a JSON post, it doesn't relay the data in JSON format, instead it kept returning an error of unable to parse JSON object.