### PR TITLE
Fixed compat with new vers of djangorestframework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django>=1.4
-djangorestframework>=2.2.0
+djangorestframework>=3.0.1
 requests>=1.1.0

--- a/rest_framework_proxy/views.py
+++ b/rest_framework_proxy/views.py
@@ -45,8 +45,8 @@ class ProxyView(BaseProxyView):
         return host
 
     def get_request_params(self, request):
-        if request.QUERY_PARAMS:
-            qp = request.QUERY_PARAMS.copy()
+        if request.query_params:
+            qp = request.query_params.copy()
             for param in self.proxy_settings.DISALLOWED_PARAMS:
                 if param in qp:
                     del qp[param]
@@ -55,10 +55,10 @@ class ProxyView(BaseProxyView):
 
     def get_request_data(self, request):
         if 'application/json' in request.content_type:
-            return json.dumps(request.DATA) if request.DATA \
+            return json.dumps(request.data) if request.data \
                     else json.dumps(request.data)
 
-        return request.DATA if request.DATA else request.data
+        return request.data if request.data else request.data
 
     def get_request_files(self, request):
         files = {}


### PR DESCRIPTION
Two methods in the Request class in djangorestframework was renamed to lowecase, and the old uppercase version has been deprecated and does not work anymore. Fixes #13