### PR TITLE
Update test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,33 @@
 language: python
 
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+
 sudo: false
 
 env:
-  - TOX_ENV=py35-django19
-  - TOX_ENV=py34-django19
-  - TOX_ENV=py27-django19
-  - TOX_ENV=py34-django18
-  - TOX_ENV=py33-django18
-  - TOX_ENV=py32-django18
-  - TOX_ENV=py27-django18
-  - TOX_ENV=py34-django17
-  - TOX_ENV=py33-django17
-  - TOX_ENV=py32-django17
-  - TOX_ENV=py27-django17
+  - Django=1.8
+  - Django=1.9
+  - Django=1.10
+  - Django=1.11
 
 matrix:
-  # Python 3.5 not yet available on travis, watch this to see when it is.
   fast_finish: true
-  allow_failures:
-    - env: TOX_ENV=py35-django19
+  include:
+    # Django 1.11 is the first version to officially support Python 3.6
+    - python: "3.6"
+      env: DJANGO=1.11
+    - python: "3.3"
+      env: DJANGO=1.8
 
 install:
-  - pip install tox
+  - pip install tox tox-travis
 
-script: tox -e $TOX_ENV
+script:
+  - tox
 
 after_success:
   - pip install codecov
-  - codecov -e TOX_ENV
+  - codecov -e TOX_ENV;DJANGO

--- a/requirements/requirements-development.txt
+++ b/requirements/requirements-development.txt
@@ -1,3 +1,3 @@
-django>=1.7
+django>=1.8
 djangorestframework>=3.1.0
 requests>=1.1.0

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,10 +1,8 @@
-# Coverage 4 isn't Python 3.2 compatible (and coveralls 1 requires coverage 4)
-coverage<4
-coveralls<1
+coverage>4
+coveralls>1
 mock>=1.0.1
 nose>=1.3.0
-# Django-nose 1.4.3 broke 3.2 compatibility
-django-nose>=1.2,<1.4.3
+django-nose>=1.4.4
 tox>=2.1.1
 
 djangorestframework>=3.1.0

--- a/setup.py
+++ b/setup.py
@@ -15,17 +15,26 @@ author = 'Tomi Pajunen'
 author_email = 'tomi@madlab.fi'
 license = 'BSD'
 install_requires = [
-    'django>=1.7',
+    'django>=1.8',
     'djangorestframework>=3.1.0',
     'requests>=1.1.0'
 ]
 classifiers = [
     'Environment :: Web Environment',
     'Framework :: Django',
+    'Framework :: Django :: 1.8',
+    'Framework :: Django :: 1.9',
+    'Framework :: Django :: 1.10',
+    'Framework :: Django :: 1.11',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,24 @@
 [tox]
 envlist =
-    {py27,py32,py33,py34}-django{17,18},
-    {py27,py34,py35}-django{19}
+    {py27,py33,py34,py35}-django{17,18},
+    {py27,py34,py35}-django{19,110}
+    {py27,py34,py35,py36}-django{111}
+
+[travis:env]
+DJANGO =
+    1.8: django18
+    1.9: django19
+    1.10: django110
+    1.11: django111
 
 [testenv]
-basepython =
-    py27: python2.7
-    py32: python3.2
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
-
 commands = coverage run --source rest_framework_proxy runtests.py
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 
 deps =
-    django17: Django==1.7.11
-    django18: Django==1.8.8
-    django19: Django==1.9.1
+    django18: Django==1.8,<1.9
+    django19: Django==1.9,<1.10
+    django110: Django==1.10,<1.11
+    django111: Django==1.11,<2.0
     -rrequirements/requirements-testing.txt


### PR DESCRIPTION
Fix unit tests in Travis.

In the process, I dropped a few older versions that are no longer supported (Django 1.7, Python 3.2)