### PR TITLE
Fixed file upload error in python3

### DIFF
--- a/rest_framework_proxy/utils.py
+++ b/rest_framework_proxy/utils.py
@@ -28,7 +28,7 @@ class StreamingMultipart(object):
     def generator(self):
         for (k, v) in self.data.items():
             yield b'%s\r\n\r\n' % self.build_multipart_header(k)
-            yield b'%s\r\n' % v
+            yield b'%s\r\n' % str(v).encode('utf-8')
 
         for (k, v) in self.files.items():
             content_type = mimetypes.guess_type(v.name)[0] or 'application/octet-stream'
@@ -58,7 +58,8 @@ class StreamingMultipart(object):
         if content_type:
             output.append('Content-Type: %s' % content_type)
 
+        output = [s.encode('utf-8') for s in output]
         return b'\r\n'.join(output)
 
     def build_multipart_footer(self):
-        return b'--%s--\r\n' % self.boundary
+        return b'--%s--\r\n' % self.boundary.encode('utf-8')

--- a/rest_framework_proxy/utils.py
+++ b/rest_framework_proxy/utils.py
@@ -27,12 +27,12 @@ class StreamingMultipart(object):
 
     def generator(self):
         for (k, v) in self.data.items():
-            yield b'%s\r\n\r\n' % self.build_multipart_header(k)
-            yield b'%s\r\n' % str(v).encode('utf-8')
+            yield ('%s\r\n\r\n' % self.build_multipart_header(k)).encode('utf-8')
+            yield ('%s\r\n' % str(v)).encode('utf-8')
 
         for (k, v) in self.files.items():
             content_type = mimetypes.guess_type(v.name)[0] or 'application/octet-stream'
-            yield b'%s\r\n\r\n' % self.build_multipart_header(k, v.name, content_type)
+            yield ('%s\r\n\r\n' % self.build_multipart_header(k, v.name, content_type)).encode('utf-8')
 
             # Seek back to start as __len__ has already read the file
             v.seek(0)
@@ -44,7 +44,7 @@ class StreamingMultipart(object):
                     break
                 yield data
             yield b'\r\n'
-        yield self.build_multipart_footer()
+        yield self.build_multipart_footer().encode('utf-8')
 
     def build_multipart_header(self, name, filename=None, content_type=None):
         output = []
@@ -58,8 +58,7 @@ class StreamingMultipart(object):
         if content_type:
             output.append('Content-Type: %s' % content_type)
 
-        output = [s.encode('utf-8') for s in output]
-        return b'\r\n'.join(output)
+        return '\r\n'.join(output)
 
     def build_multipart_footer(self):
-        return b'--%s--\r\n' % self.boundary.encode('utf-8')
+        return '--%s--\r\n' % self.boundary

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,3 +1,4 @@
+import mimetypes
 import requests
 
 from io import BytesIO
@@ -42,7 +43,8 @@ class StreamingMultipartTests(TestCase):
         self.assertEqual(data_body, expected_data_body)
 
         file_mpheader = next(generator)
-        expected_file_mpheader = b'--ddd37654bd80490fa3c58987954aa380\r\nContent-Disposition: form-data; name="file"; filename="test_file.dat"\r\nContent-Type: application/octet-stream\r\n\r\n'
+        content_type = mimetypes.guess_type('test_file.dat')[0] or 'application/octet-stream'
+        expected_file_mpheader = b'--ddd37654bd80490fa3c58987954aa380\r\nContent-Disposition: form-data; name="file"; filename="test_file.dat"\r\nContent-Type: %s\r\n\r\n' % content_type.encode('utf-8')
         self.assertEqual(file_mpheader, expected_file_mpheader)
 
         file_body = next(generator)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -44,7 +44,7 @@ class StreamingMultipartTests(TestCase):
 
         file_mpheader = next(generator)
         content_type = mimetypes.guess_type('test_file.dat')[0] or 'application/octet-stream'
-        expected_file_mpheader = b'--ddd37654bd80490fa3c58987954aa380\r\nContent-Disposition: form-data; name="file"; filename="test_file.dat"\r\nContent-Type: %s\r\n\r\n' % content_type.encode('utf-8')
+        expected_file_mpheader = ('--ddd37654bd80490fa3c58987954aa380\r\nContent-Disposition: form-data; name="file"; filename="test_file.dat"\r\nContent-Type: %s\r\n\r\n' % content_type).encode('utf-8')
         self.assertEqual(file_mpheader, expected_file_mpheader)
 
         file_body = next(generator)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,61 @@
+import requests
+
+from io import BytesIO
+from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.http.request import QueryDict
+from django.test import TestCase
+from mock import Mock, patch
+
+from rest_framework_proxy.utils import StreamingMultipart
+
+
+class StreamingMultipartTests(TestCase):
+
+    def test_generator(self):
+        upload_bstr = b'test binary data'
+        upload_file = BytesIO()
+        upload_file.write(upload_bstr)
+        upload_file.seek(0)
+        upload_data = InMemoryUploadedFile(upload_file,
+                                           'file',
+                                           'test_file.dat',
+                                           'application/octet-stream',
+                                           len(upload_bstr),
+                                           None,
+                                           content_type_extra={})
+
+        data = QueryDict(mutable=True)
+        data['file'] = upload_data
+        files = {'file': upload_data}
+        boundary = 'ddd37654bd80490fa3c58987954aa380'
+
+        streamingMultiPart = StreamingMultipart(data, files, boundary)
+        generator = streamingMultiPart.generator()
+
+
+        data_mpheader = next(generator)
+        expected_data_mpheader = b'--ddd37654bd80490fa3c58987954aa380\r\nContent-Disposition: form-data; name="file"\r\n\r\n'
+        self.assertEqual(data_mpheader, expected_data_mpheader)
+
+        data_body = next(generator)
+        expected_data_body = b'test_file.dat\r\n'
+        self.assertEqual(data_body, expected_data_body)
+
+        file_mpheader = next(generator)
+        expected_file_mpheader = b'--ddd37654bd80490fa3c58987954aa380\r\nContent-Disposition: form-data; name="file"; filename="test_file.dat"\r\nContent-Type: application/octet-stream\r\n\r\n'
+        self.assertEqual(file_mpheader, expected_file_mpheader)
+
+        file_body = next(generator)
+        expected_file_body = b'test binary data'
+        self.assertEqual(file_body, expected_file_body)
+        self.assertEqual(next(generator), b'\r\n')
+
+        mpfooter = next(generator)
+        expected_mpfooter = b'--ddd37654bd80490fa3c58987954aa380--\r\n'
+        self.assertEqual(mpfooter, expected_mpfooter)
+
+        try:
+            v = next(generator)
+            self.fail('Unexpected iteration - %r' % v)
+        except StopIteration:
+            pass


### PR DESCRIPTION
I got the following error on file upload when running the server process in python3.

```
  File "....../rest_framework_proxy/utils.py", line 61, in build_multipart_header
    return b'\r\n'.join(output)
TypeError: sequence item 0: expected a bytes-like object, str found
```

This happens because `output` is not binary string. I made changes to encode string into binary string in the utils module.