### PR TITLE
Add setting to return raw error responses

### DIFF
--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -4,5 +4,6 @@ mock>=1.0.1
 nose>=1.3.0
 django-nose>=1.4.4
 tox>=2.1.1
+responses>=0.6.0
 
 djangorestframework>=3.1.0

--- a/rest_framework_proxy/settings.py
+++ b/rest_framework_proxy/settings.py
@@ -20,6 +20,9 @@ DEFAULTS = {
     # Return response as-is if enabled
     'RETURN_RAW': False,
 
+    # Return failure response as-is if code >= 400
+    'RETURN_RAW_ERROR': False,
+
     # Used to translate Accept HTTP field
     'ACCEPT_MAPS': {
         'text/html': 'application/json',

--- a/rest_framework_proxy/views.py
+++ b/rest_framework_proxy/views.py
@@ -22,6 +22,7 @@ class BaseProxyView(APIView):
     proxy_host = None
     source = None
     return_raw = False
+    return_raw_error = False
     verify_ssl = None
 
 
@@ -131,11 +132,13 @@ class ProxyView(BaseProxyView):
             return parsed
 
     def create_response(self, response):
-        if self.return_raw or self.proxy_settings.RETURN_RAW:
+        status = response.status_code
+        if ((self.return_raw or self.proxy_settings.RETURN_RAW) or
+            (status >= 400 and (self.return_raw_error or self.proxy_settings.RETURN_RAW_ERROR))):
+
             return HttpResponse(response.text, status=response.status_code,
                     content_type=response.headers.get('content-type'))
 
-        status = response.status_code
         if status >= 400:
             body = {
                 'code': status,


### PR DESCRIPTION
I'm using this proxy library for a project where I'd like the downstream errors to be funneled back through the proxy.  I was able to accomplish this for my project by extending the create_response() function in my code, but I thought this might be a feature that others might like.

By default, the functionality of the library doesn't change.  If you set RETURN_RAW_ERROR for a proxy, then it'll pass responses through if status_code >= 400, similar to how RETURN_RAW works.

The tests should do a good job of illustrating the functionality, but let me know if you have any questions.