### PR TITLE
Fixed content error when response is binary file

### DIFF
--- a/rest_framework_proxy/views.py
+++ b/rest_framework_proxy/views.py
@@ -133,7 +133,7 @@ class ProxyView(BaseProxyView):
     def create_response(self, response):
         if self.return_raw or self.proxy_settings.RETURN_RAW:
             return HttpResponse(content=response.content, status=response.status_code,
-                    content_type=response.headers.get('content-type'))
+                    content_type=response.headers.get('content-type'), charset=response.encoding)
 
         status = response.status_code
         if status >= 400:

--- a/rest_framework_proxy/views.py
+++ b/rest_framework_proxy/views.py
@@ -132,7 +132,7 @@ class ProxyView(BaseProxyView):
 
     def create_response(self, response):
         if self.return_raw or self.proxy_settings.RETURN_RAW:
-            return HttpResponse(response.text, status=response.status_code,
+            return HttpResponse(content=response.content, status=response.status_code,
                     content_type=response.headers.get('content-type'))
 
         status = response.status_code

--- a/tests/views_tests.py
+++ b/tests/views_tests.py
@@ -81,13 +81,13 @@ class ProxyViewTests(TestCase):
                 self.assertEqual(request_data.files, {'file': upload_data})
                 self.assertEqual(request_data.data['file'], upload_data)
 
-    def test_post_audio_file_return_raw(self):
+    def test_return_raw_audio_file(self):
         view = ProxyView()
         view.return_raw = True
         test_content = b'ID3\x04\x00\x00\x00\x00\x00#TSSE\x00\x00\x00\x0f\x00\x00\x03Lavf57.71.100\x00\xff\xf3'
 
         factory = APIRequestFactory()
-        request = factory.post('http://someurl')
+        request = factory.get('http://someurl')
         request.content_type = 'audio/mpeg'
         request.query_params = ''
         request.data = QueryDict(mutable=True)

--- a/tests/views_tests.py
+++ b/tests/views_tests.py
@@ -81,6 +81,28 @@ class ProxyViewTests(TestCase):
                 self.assertEqual(request_data.files, {'file': upload_data})
                 self.assertEqual(request_data.data['file'], upload_data)
 
+    def test_post_audio_file_return_raw(self):
+        view = ProxyView()
+        view.return_raw = True
+        test_content = b'ID3\x04\x00\x00\x00\x00\x00#TSSE\x00\x00\x00\x0f\x00\x00\x03Lavf57.71.100\x00\xff\xf3'
+
+        factory = APIRequestFactory()
+        request = factory.post('http://someurl')
+        request.content_type = 'audio/mpeg'
+        request.query_params = ''
+        request.data = QueryDict(mutable=True)
+
+        with patch.object(requests.sessions.Session, 'request') as patched_request:
+            def side_effect(*args, **kwargs):
+                response = requests.models.Response()
+                response._content = test_content
+                response._content_consumed = True
+                response.status_code = 200
+                return response
+            patched_request.side_effect = side_effect
+            result = view.proxy(request)
+            assert result.content == test_content
+
 
 class ProxyViewHeadersTest(TestCase):
 


### PR DESCRIPTION
With return_raw set to true, I got wrong content in the response data when trying to proxy an API that returns an mp3 file.

Seems that we are using the response.text field even for binary content.
And what happens inside response.text is:

```content = str(self.content, errors='replace')```

And then we encode the result string with utf-8.

Fixed that by setting the content field instead in the HttpResponse.

A test case for the return raw case is provided.
