### PR TITLE
Django 3 compatibility: django.utils.six has been removed

### DIFF
--- a/requirements/requirements-development.txt
+++ b/requirements/requirements-development.txt
@@ -1,3 +1,4 @@
 django>=1.8
 djangorestframework>=3.1.0
 requests>=1.1.0
+six>=1.10.0

--- a/rest_framework_proxy/views.py
+++ b/rest_framework_proxy/views.py
@@ -2,8 +2,13 @@ import base64
 import json
 import requests
 
-from django.utils import six
-from django.utils.six import BytesIO as StringIO
+try:
+    from django.utils import six
+    from django.utils.six import BytesIO as StringIO
+except ImportError:
+    import six
+    from six import BytesIO as StringIO
+
 from requests.exceptions import ConnectionError, SSLError, Timeout
 from requests import sessions
 from django.http import HttpResponse

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ license = 'BSD'
 install_requires = [
     'django>=1.8',
     'djangorestframework>=3.1.0',
-    'requests>=1.1.0'
+    'requests>=1.1.0',
+    'six>=1.10.0',
 ]
 classifiers = [
     'Environment :: Web Environment',


### PR DESCRIPTION
[Django 3 removed some Python 2 compatibility libraries](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis) which this project depends on, making it impossible right now to upgrade to Django 3.

This PR patches the problem by catching the `ImportError` and importing `six` directly instead. It also adds `six` as a dependency (in the version as it was available in Django 2.2).

A full fix would be to drop `six` altogether since Python 2 is officially retired now and no longer supported by Django, but this is beyond the scope of this PR.